### PR TITLE
Consolidate past work changes

### DIFF
--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -19,6 +19,7 @@
     ~/.mpdconf: mpd/mpdconf
     ~/.my.cnf: mysql/my.cnf
     ~/.pryrc: pry/pryrc
+    ~/.rspec: ruby/rspec
     ~/.tigrc: tig/tigrc
     ~/.tmux-osx.conf: tmux/tmux-osx.conf
     ~/.tmux.conf: tmux/tmux.conf

--- a/pry/pryrc
+++ b/pry/pryrc
@@ -1,8 +1,107 @@
-require "rubygems"
-require "awesome_print"
+# Pry Config
+#----------------------------------------------------------------------------
+Pry.config.editor = "vim"
 
-Pry.print = proc { |output, value| output.puts value.ai }
+# If in bundler, break out, so awesome print doesn't have to be in Gemfile
+#----------------------------------------------------------------------------
+if defined?(::Bundler) and File.exist?(ENV['GEM_HOME'])
+  $LOAD_PATH.concat Dir.glob("#{ENV['GEM_HOME']}/gems/*/lib")
+end
 
-Pry.commands.alias_command 'c', 'continue'
-Pry.commands.alias_command 's', 'step'
-Pry.commands.alias_command 'n', 'next'
+# Pry Default Logger
+#----------------------------------------------------------------------------
+
+# Use awesome_print with Pry
+# Taken from: https://github.com/pry/pry/wiki/FAQ#wiki-awesome_print
+begin
+  require 'awesome_print'
+  Pry.config.print = proc { |output, value| Pry::Helpers::BaseHelpers.stagger_output("=> #{value.ai}", output) }
+rescue LoadError => err
+  puts "no awesome_print :("
+end
+
+if defined?(Rails)
+  if defined?(ActiveRecord)
+    ActiveRecord::Base.logger = Logger.new(STDOUT)
+    ActiveRecord::Base.clear_active_connections!
+    ActiveSupport::Cache::Store.logger = Logger.new(STDOUT)
+  end
+end
+
+command_set = Pry::CommandSet.new do
+
+  command "clear" do
+    system 'clear'
+    if defined?(Rails)
+      output.puts "Rails Environment: " + Rails.env
+    end
+  end
+
+  # command "sql", "Send sql over AR." do |query|
+  #   if ENV['RAILS_ENV'] || defined?(Rails)
+  #     ap ActiveRecord::Base.connection.select_all(query)
+  #   else
+  #     ap "Pry did not require the environment, try `pconsole`"
+  #   end
+  # end
+
+  # command "reload", "Reload specified source file or previously reloaded file by default." do |file|
+  #   unless file
+  #     if $wl__reload_file
+  #       load($wl__reload_file)
+  #       next
+  #     end
+
+  #     files = Dir["*.rb"]
+  #     case files.size
+  #     when 0
+  #       output.puts "No Ruby files in #{Dir.pwd}"
+  #       next
+  #     when 1
+  #       file = files.first
+  #     else
+  #       output.puts "Many Ruby files in #{Dir.pwd}:"
+  #       output.puts files.map{|f| "\t#{f}"}
+  #       next
+  #     end
+  #   end
+
+  #   file = file.sub(/(\.rb)?$/, '.rb')
+  #   $wl__reload_file = file
+  #   load(file)
+  # end
+
+  # alias_command "r", "reload"
+
+end
+
+Pry.config.commands.import command_set
+
+
+# If in bundler, break out, so awesome print and other gems don't have to be in Gemfile
+#----------------------------------------------------------------------------
+# if defined?(Bundler)
+#   Gem.post_reset_hooks.reject! { |hook| hook.source_location.first =~ %r{/bundler/} }
+#   Gem::Specification.reset
+#   load 'rubygems/custom_require.rb'
+# end
+
+
+# # Load Pry Gems (awesome_print, pry-doc, pry-nav)
+# #----------------------------------------------------------------------------
+# %w[awesome_print pry-doc pry-nav pry-remote].each  do |gem|
+#   begin
+#     puts "requiring #{gem}"
+#     require gem
+#     if gem == 'pry-nav'
+#       Pry.commands.alias_command 'c', 'continue'
+#       Pry.commands.alias_command 's', 'step'
+#       Pry.commands.alias_command 'n', 'next'
+#     end
+#     if gem == 'awesome_print'
+#       Pry.config.print = proc { |output, value| output.puts "=> #{ap value}" }
+#     end
+#   rescue LoadError
+#     warn "Unable to load #{gem}"
+#   end
+# end

--- a/ruby/rspec
+++ b/ruby/rspec
@@ -1,0 +1,4 @@
+--backtrace
+--color
+--format documentation
+--profile

--- a/system/editrc
+++ b/system/editrc
@@ -1,2 +1,20 @@
+# The libedit library is similar to readline—a library used to make interactive
+# editing work in many command line tools like bash—and is configured via
+# ~/.editrc.
+
 # Enable vi keybindings in irb and pry when readline is not available
-# bind -v # comment this out to enable tab completion, but lose vim keybindings
+
+# Use vi mode.
+bind -v
+
+# Tab to complete.
+bind \\t rl_complete
+
+# Reverse search through history.
+bind "^R" em-inc-search-prev
+
+# Alternative to ESC.
+bind "jk" vi-command-mode
+
+# Clear the screen.
+bind "^L" ed-clear-screen

--- a/system/env.zsh
+++ b/system/env.zsh
@@ -14,9 +14,6 @@ export EDITOR='vim'
 
 export DISPLAY=:16.0
 
-# your project folder so that we can `c [tab]` to
-export PROJECTS=~/code
-
 # Add colours to ls output (OS X)
 export LSCOLORS="exfxcxdxbxegedabagacad"
 export CLICOLOR=true

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -8,10 +8,6 @@
 
 set nocompatible " must be first line
 
-if filereadable(expand("~/.localvimrc"))
-  source ~/.localvimrc
-endif
-
 " Configure minpac plugin management {
 
   " Load and initialize minpac and define plugins to be installed.
@@ -438,4 +434,11 @@ endif
           set fuoptions=maxvert,maxhorz         " fullscreen options (MacVim only), resized window when changed to fullscreen (max lines and columns)
         endif
     " }
+" }
+
+" Local overrides
+  let $LOCALFILE=expand("~/.vimrc_local")
+  if filereadable($LOCALFILE)
+      source $LOCALFILE
+  endif
 " }

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -288,6 +288,10 @@ set nocompatible " must be first line
   " fzf.vim — https://github.com/junegunn/fzf.vim {
     nnoremap <silent> <LocalLeader>ff :Files<CR>
     nnoremap <silent> <LocalLeader>fs :Snippets<CR>
+    nnoremap <silent> <LocalLeader>fw :Windows<CR>
+    nnoremap <silent> <LocalLeader>fl :Lines<CR>
+    nnoremap <silent> <LocalLeader>fa :Ag<CR>
+    nnoremap <silent> <LocalLeader>fh :History<CR>
   " }
 
 " }

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -401,12 +401,16 @@ set nocompatible " must be first line
       " let g:ycm_auto_trigger = 0
       " let g:ycm_key_list_select_completion = []
       " let g:ycm_key_list_previous_completion = []
+      nnoremap <leader>jd :YcmCompleter GoToDefinition<CR>
+      if !exists("g:ycm_semantic_triggers")
+        let g:ycm_semantic_triggers = {}
+      endif
+      let g:ycm_semantic_triggers['typescript'] = ['.']
   " }
 
   " Syntastic {
       let g:syntastic_html_tidy_ignore_errors=[" proprietary attribute", "is not recognized!","discarding unexpected"]
   " }
-
 
   " FZF — https://github.com/junegunn/fzf {
       " This is required to load the basic vim plugin that comes with fzf.

--- a/zsh/zshenv
+++ b/zsh/zshenv
@@ -56,3 +56,7 @@ bindkey '^?' backward-delete-char
 bindkey '^R' history-incremental-search-backward
 bindkey '^F' history-incremental-search-forward
 
+# Make sure enter key behaves when interacting with interactive programs. See
+# http://askubuntu.com/questions/441744/pressing-enter-produces-m-instead-of-a-newline
+# for more information.
+stty icrnl

--- a/zsh/zshenv
+++ b/zsh/zshenv
@@ -41,6 +41,11 @@ zle -N newtab
 
 bindkey -v # use vi key bindings
 
+# Enable editing in vim by typing "v" in "command mode". Same as typing ESC-v.
+autoload edit-command-line
+zle -N edit-command-line
+bindkey -M vicmd v edit-command-line
+
 bindkey '^[^[[D' backward-word
 bindkey '^[^[[C' forward-word
 bindkey '^[[5D' beginning-of-line


### PR DESCRIPTION
Consolidate a number of useful dotfile config updates made at work over the last few years that haven’t been committed in a long time.

* Define custom `rspec` flags
* Update `pryrc`
* Make `pry`, `irb` and other `libedit` tools behave more naturally
* Minor `vimrc` updates
* Move natural ZSH command line editing